### PR TITLE
Add CreateBackup for creating a backup from a directory

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -1,0 +1,47 @@
+package badgerutils
+
+import (
+	"log"
+	"os"
+	"path"
+	"time"
+
+	"github.com/dgraph-io/badger"
+)
+
+// CreateBackup creates a backup from a Badger database directory.
+func CreateBackup(dir, backupPath, backupName string) (uint64, error) {
+	var version uint64
+
+	opts := badger.DefaultOptions
+	opts.Dir = dir
+	opts.ValueDir = dir
+	db, err := badger.Open(opts)
+	if err != nil {
+		return 0, err
+	}
+	defer db.Close()
+
+	if err := os.MkdirAll(backupPath, os.ModePerm); err != nil {
+		return version, err
+	}
+
+	outputPath := path.Join(backupPath, backupName)
+
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return version, err
+	}
+
+	start := time.Now()
+
+	version, err = db.Backup(file, 0)
+	if err != nil {
+		return version, err
+	}
+
+	end := time.Now()
+	elapsed := end.Sub(start)
+	log.Printf("Created backup in %v", elapsed)
+	return version, nil
+}

--- a/backup_test.go
+++ b/backup_test.go
@@ -1,0 +1,33 @@
+package badgerutils
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackup(t *testing.T) {
+	dir, err := os.Getwd()
+	require.Nil(t, err)
+	tmpDir, err := ioutil.TempDir(dir, "temp")
+	require.Nil(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := path.Join(tmpDir, "db")
+	backupPath := path.Join(tmpDir, "path", "to", "backup")
+	backupName := "db.bak"
+
+	reader := strings.NewReader(`field11,field12,field13
+field21,field22,field23
+field31,field32,field33`)
+	err = WriteStream(reader, dbPath, 2, csvToSampleRecord)
+	require.Nil(t, err)
+
+	_, err = CreateBackup(dbPath, backupPath, backupName)
+	require.Nil(t, err)
+	require.FileExists(t, path.Join(backupPath, backupName))
+}

--- a/badgerutils.go
+++ b/badgerutils.go
@@ -1,0 +1,2 @@
+// Package badgerutils provides functions for interacting with Badger.
+package badgerutils

--- a/writer.go
+++ b/writer.go
@@ -1,4 +1,3 @@
-// Package badgerutils provides functions for interacting with Badger.
 package badgerutils
 
 import (
@@ -8,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -75,6 +75,10 @@ func writeBatch(kvs []keyValue, db *badger.DB, cherr chan error, done func(int32
 // lineToKeyed function parameter defines how stdin is translated to a value and how to define a key
 // from that value.
 func WriteStream(reader io.Reader, dir string, batchSize int, lineToKeyed func(string) (Keyed, error)) error {
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return err
+	}
+
 	// Open Badger database from directory
 	opts := badger.DefaultOptions
 	opts.Dir = dir

--- a/writer_test.go
+++ b/writer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"strings"
 	"testing"
 
@@ -84,13 +85,15 @@ func TestWriteStream(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(tmpDir)
 
+	dbPath := path.Join(tmpDir, "path", "to", "db")
+
 	reader := strings.NewReader(`field11,field12,field13
 field21,field22,field23
 field31,field32,field33`)
-	err = WriteStream(reader, tmpDir, 2, csvToSampleRecord)
+	err = WriteStream(reader, dbPath, 2, csvToSampleRecord)
 	require.Nil(t, err)
 
-	writtenSampleRecords, err := readDB(tmpDir)
+	writtenSampleRecords, err := readDB(dbPath)
 	require.Nil(t, err)
 	require.Equal(t, 3, len(writtenSampleRecords))
 	require.EqualValues(t, writtenSampleRecords[0], sampleRecord{"field11", "field12", "field13"})


### PR DESCRIPTION
# CreateBackup
This PR adds `CreateBackup` to `badgerutils` for creating a backup from a database directory.

## Cleanup
- Moved godoc comment for `badgerutils` into `badgerutils.go`.
- Modified `WriteStream` to make sure database path exists (otherwise create it) before attempting to use it.