### PR TITLE
Test restored DB backup

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -18,11 +18,11 @@ func CreateBackup(dir, backupPath, backupName string) (uint64, error) {
 	opts.ValueDir = dir
 	db, err := badger.Open(opts)
 	if err != nil {
-		return 0, err
+		return version, err
 	}
 	defer db.Close()
 
-	if err := os.MkdirAll(backupPath, os.ModePerm); err != nil {
+	if err = os.MkdirAll(backupPath, os.ModePerm); err != nil {
 		return version, err
 	}
 

--- a/backup_test.go
+++ b/backup_test.go
@@ -7,8 +7,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dgraph-io/badger"
 	"github.com/stretchr/testify/require"
 )
+
+func restoreBackup(dir, backupFilePath string) error {
+	opts := badger.DefaultOptions
+	opts.Dir = dir
+	opts.ValueDir = dir
+	db, err := badger.Open(opts)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	file, err := os.Open(backupFilePath)
+	if err != nil {
+		return err
+	}
+	db.Load(file)
+	return nil
+}
 
 func TestBackup(t *testing.T) {
 	dir, err := os.Getwd()
@@ -27,7 +45,19 @@ field31,field32,field33`)
 	err = WriteStream(reader, dbPath, 2, csvToSampleRecord)
 	require.Nil(t, err)
 
+	backupFilePath := path.Join(backupPath, backupName)
 	_, err = CreateBackup(dbPath, backupPath, backupName)
 	require.Nil(t, err)
-	require.FileExists(t, path.Join(backupPath, backupName))
+	require.FileExists(t, backupFilePath)
+
+	restoredDBPath := path.Join(tmpDir, "restored_db")
+	err = restoreBackup(restoredDBPath, backupFilePath)
+	require.Nil(t, err)
+
+	restoredSampleRecords, err := readDB(restoredDBPath)
+	require.Nil(t, err)
+	require.Equal(t, 3, len(restoredSampleRecords))
+	require.EqualValues(t, restoredSampleRecords[0], sampleRecord{"field11", "field12", "field13"})
+	require.EqualValues(t, restoredSampleRecords[1], sampleRecord{"field21", "field22", "field23"})
+	require.EqualValues(t, restoredSampleRecords[2], sampleRecord{"field31", "field32", "field33"})
 }

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -1,0 +1,74 @@
+package badgerutils
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"strings"
+
+	"github.com/dgraph-io/badger"
+)
+
+type sampleRecord struct {
+	Field1 string
+	Field2 string
+	Field3 string
+}
+
+func (r sampleRecord) Key() string {
+	return fmt.Sprintf("%v,%v,%v", r.Field1, r.Field2, r.Field3)
+}
+
+func csvToSampleRecord(line string) (Keyed, error) {
+	values := strings.Split(line, ",")
+	return sampleRecord{values[0], values[1], values[2]}, nil
+}
+
+func readDB(dir string) ([]sampleRecord, error) {
+	opts := badger.DefaultOptions
+	opts.Dir = dir
+	opts.ValueDir = dir
+	db, err := badger.Open(opts)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	chkv, cherr := make(chan keyValue), make(chan error)
+	go func(chan keyValue, chan error) {
+		err := db.View(func(txn *badger.Txn) error {
+			opts := badger.DefaultIteratorOptions
+			it := txn.NewIterator(opts)
+			defer it.Close()
+			for it.Rewind(); it.Valid(); it.Next() {
+				item := it.Item()
+				key := item.Key()
+				value, err := item.Value()
+				if err != nil {
+					return err
+				}
+				kv := keyValue{key, value}
+				chkv <- kv
+			}
+			close(chkv)
+			return nil
+		})
+		cherr <- err
+	}(chkv, cherr)
+
+	sampleRecords := make([]sampleRecord, 0)
+	for kv := range chkv {
+		var sr sampleRecord
+		buf := bytes.NewReader(kv.Value)
+		if err := gob.NewDecoder(buf).Decode(&sr); err != nil {
+			return nil, err
+		}
+		sampleRecords = append(sampleRecords, sr)
+	}
+
+	if err := <-cherr; err != nil {
+		return nil, err
+	}
+
+	return sampleRecords, nil
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,82 +1,14 @@
 package badgerutils
 
 import (
-	"bytes"
-	"encoding/gob"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
 
-	"github.com/dgraph-io/badger"
 	"github.com/stretchr/testify/require"
 )
-
-type sampleRecord struct {
-	Field1 string
-	Field2 string
-	Field3 string
-}
-
-func (r sampleRecord) Key() string {
-	return fmt.Sprintf("%v,%v,%v", r.Field1, r.Field2, r.Field3)
-}
-
-func csvToSampleRecord(line string) (Keyed, error) {
-	values := strings.Split(line, ",")
-	return sampleRecord{values[0], values[1], values[2]}, nil
-}
-
-func readDB(dir string) ([]sampleRecord, error) {
-	opts := badger.DefaultOptions
-	opts.Dir = dir
-	opts.ValueDir = dir
-	db, err := badger.Open(opts)
-	if err != nil {
-		return nil, err
-	}
-	defer db.Close()
-
-	chkv, cherr := make(chan keyValue), make(chan error)
-	go func(chan keyValue, chan error) {
-		err := db.View(func(txn *badger.Txn) error {
-			opts := badger.DefaultIteratorOptions
-			it := txn.NewIterator(opts)
-			defer it.Close()
-			for it.Rewind(); it.Valid(); it.Next() {
-				item := it.Item()
-				key := item.Key()
-				value, err := item.Value()
-				if err != nil {
-					return err
-				}
-				kv := keyValue{key, value}
-				chkv <- kv
-			}
-			close(chkv)
-			return nil
-		})
-		cherr <- err
-	}(chkv, cherr)
-
-	sampleRecords := make([]sampleRecord, 0)
-	for kv := range chkv {
-		var sr sampleRecord
-		buf := bytes.NewReader(kv.Value)
-		if err := gob.NewDecoder(buf).Decode(&sr); err != nil {
-			return nil, err
-		}
-		sampleRecords = append(sampleRecords, sr)
-	}
-
-	if err := <-cherr; err != nil {
-		return nil, err
-	}
-
-	return sampleRecords, nil
-}
 
 func TestWriteStream(t *testing.T) {
 	dir, err := os.Getwd()


### PR DESCRIPTION
This PR adds to the `CreateBackup` test to check the records found in the DB restored from the backup file. It also does a little bit of #8.

This PR came about because the size of the backup file was not what I expected and I wanted to confirm that the backup file was correct.