### PR TITLE
Optimize for low memory usage

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -5,18 +5,13 @@ import (
 	"os"
 	"path"
 	"time"
-
-	"github.com/dgraph-io/badger"
 )
 
 // CreateBackup creates a backup from a Badger database directory.
 func CreateBackup(dir, backupPath, backupName string) (uint64, error) {
 	var version uint64
 
-	opts := badger.DefaultOptions
-	opts.Dir = dir
-	opts.ValueDir = dir
-	db, err := badger.Open(opts)
+	db, err := openDB(dir)
 	if err != nil {
 		return version, err
 	}

--- a/backup_test.go
+++ b/backup_test.go
@@ -7,15 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dgraph-io/badger"
 	"github.com/stretchr/testify/require"
 )
 
 func restoreBackup(dir, backupFilePath string) error {
-	opts := badger.DefaultOptions
-	opts.Dir = dir
-	opts.ValueDir = dir
-	db, err := badger.Open(opts)
+	db, err := openDB(dir)
 	if err != nil {
 		return err
 	}

--- a/db.go
+++ b/db.go
@@ -1,0 +1,15 @@
+package badgerutils
+
+import (
+	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/badger/options"
+)
+
+func openDB(dir string) (*badger.DB, error) {
+	opts := badger.DefaultOptions
+	opts.ValueLogLoadingMode = options.FileIO
+	opts.TableLoadingMode = options.FileIO
+	opts.Dir = dir
+	opts.ValueDir = dir
+	return badger.Open(opts)
+}

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -25,10 +25,7 @@ func csvToSampleRecord(line string) (Keyed, error) {
 }
 
 func readDB(dir string) ([]sampleRecord, error) {
-	opts := badger.DefaultOptions
-	opts.Dir = dir
-	opts.ValueDir = dir
-	db, err := badger.Open(opts)
+	db, err := openDB(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/writer.go
+++ b/writer.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger"
-	"github.com/dgraph-io/badger/options"
 )
 
 // Keyed interface defines a Key method for defining a key from a struct.
@@ -80,13 +79,7 @@ func WriteStream(reader io.Reader, dir string, batchSize int, lineToKeyed func(s
 		return err
 	}
 
-	// Open Badger database from directory
-	opts := badger.DefaultOptions
-	opts.ValueLogLoadingMode = options.FileIO
-	opts.TableLoadingMode = options.FileIO
-	opts.Dir = dir
-	opts.ValueDir = dir
-	db, err := badger.Open(opts)
+	db, err := openDB(dir)
 	if err != nil {
 		return err
 	}

--- a/writer.go
+++ b/writer.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/badger/options"
 )
 
 // Keyed interface defines a Key method for defining a key from a struct.
@@ -81,6 +82,8 @@ func WriteStream(reader io.Reader, dir string, batchSize int, lineToKeyed func(s
 
 	// Open Badger database from directory
 	opts := badger.DefaultOptions
+	opts.ValueLogLoadingMode = options.FileIO
+	opts.TableLoadingMode = options.FileIO
 	opts.Dir = dir
 	opts.ValueDir = dir
 	db, err := badger.Open(opts)


### PR DESCRIPTION
This PR tunes our use of Badger to be able to run in lower memory environments. See https://github.com/dgraph-io/badger#memory-usage for some background.

## Performance

In theory loading the tree from RAM and the values from a memory mapped file should be faster but it didn't look like setting both of these to read from disk had any impact on performance (on AWS EC2 instances with SSD instance storage).

Since there was no noticeable impact on performance I made these options the defaults.

Also in theory the LSM tree (`TableLoadingMode`) should have a small footprint but in my tests it looked like there was quite a bit of memory usage still.